### PR TITLE
Fix: api tests suppose to run sequential

### DIFF
--- a/tests/Api.Tests/Api.Tests.csproj
+++ b/tests/Api.Tests/Api.Tests.csproj
@@ -32,6 +32,9 @@
       <None Update="testsettings.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
+      <None Update="xunit.runner.json">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/tests/Api.Tests/Fixtures/ApiTestFixture.cs
+++ b/tests/Api.Tests/Fixtures/ApiTestFixture.cs
@@ -1,4 +1,5 @@
 using Api;
+using App.Data;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,6 +31,11 @@ public class ApiTestFixture : IClassFixture<ApiWebApplicationFactory>, IDisposab
         return Factory.Services.CreateScope();
     }
 
+    public Context GetScopedContext()
+    {
+        return CreateScope().ServiceProvider.GetService<Context>()!;
+    }
+
     public ApiTestFixture(ApiWebApplicationFactory factory)
     {
         Factory = factory;
@@ -39,6 +45,9 @@ public class ApiTestFixture : IClassFixture<ApiWebApplicationFactory>, IDisposab
             AllowAutoRedirect = false,
             HandleCookies = true
         });
+        using var context = GetScopedContext();
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
         // if needed, reset the DB
         //_checkpoint.Reset(_factory.Configuration.GetConnectionString("SQL")).Wait();
     }

--- a/tests/Api.Tests/Fixtures/ApiTestFixture.cs
+++ b/tests/Api.Tests/Fixtures/ApiTestFixture.cs
@@ -1,12 +1,13 @@
 using Api;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Api.Tests.Fixtures;
 
 [Trait("Category", "Integration")]
-public class ApiTestFixture : IClassFixture<ApiWebApplicationFactory>
+public class ApiTestFixture : IClassFixture<ApiWebApplicationFactory>, IDisposable
 {
     protected readonly ApiWebApplicationFactory Factory;
     protected readonly HttpClient Api;
@@ -40,5 +41,10 @@ public class ApiTestFixture : IClassFixture<ApiWebApplicationFactory>
         });
         // if needed, reset the DB
         //_checkpoint.Reset(_factory.Configuration.GetConnectionString("SQL")).Wait();
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
     }
 }

--- a/tests/Api.Tests/xunit.runner.json
+++ b/tests/Api.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
I haven't found a good cookbook for integration tests setup. Instead of solving an issue of conflicting setups, lets avoid it FOR NOW.